### PR TITLE
add type to checkin

### DIFF
--- a/Master/azcollect.js
+++ b/Master/azcollect.js
@@ -55,6 +55,7 @@ class Azcollect extends m_alServiceC.AlServiceC {
 
     checkin(collectorType, collectorId, statusVal, descriptionVal) {
         let statusBody = {
+            type : collectorType,
             version : m_version.getVersion(),
             status : statusVal,
             description : descriptionVal


### PR DESCRIPTION
**Problem**
We don't use `type` in checkin.

**Solution**
Hardcode `o365`.

@kkuzmin @ikemsley 