### PR TITLE
Init TableService once.

### DIFF
--- a/Master/appstats.js
+++ b/Master/appstats.js
@@ -12,28 +12,29 @@ const async = require('async');
 const util = require('util');
 const moment = require('moment');
 const parse = require('parse-key-value');
+const azureStorage = require('azure-storage');
+
 
 const m_alUtil = require('../lib/al_util');
 
 const STATS_PERIOD_MINUTES = 15;
 const APP_FUNCTIONS = ['Master', 'O365WebHook', 'Updater'];
 
-var azureStorage = require('azure-storage');
 var TableQuery = azureStorage.TableQuery;
 var TableUtilities = azureStorage.TableUtilities;
-var TableService = null;
+var g_tableService = null;
 
 var _initTableService = function() {
     const storageParams = parse(process.env.AzureWebJobsStorage);
-    TableService = azureStorage.createTableService(
+    g_tableService = azureStorage.createTableService(
         storageParams.AccountName, 
         storageParams.AccountKey, 
         storageParams.AccountName + '.table.core.windows.net');
-    return TableService;
+    return g_tableService;
 };
 
 var getTableService = function() {
-    return (TableService) ? TableService : _initTableService();
+    return (g_tableService) ? g_tableService : _initTableService();
 };
 
 var getLogTableName = function() {

--- a/Master/appstats.js
+++ b/Master/appstats.js
@@ -25,10 +25,11 @@ var TableService = null;
 
 var _initTableService = function() {
     const storageParams = parse(process.env.AzureWebJobsStorage);
-    return azureStorage.createTableService(
+    TableService = azureStorage.createTableService(
         storageParams.AccountName, 
         storageParams.AccountKey, 
         storageParams.AccountName + '.table.core.windows.net');
+    return TableService;
 };
 
 var getTableService = function() {

--- a/test/master_appstats_test.js
+++ b/test/master_appstats_test.js
@@ -24,7 +24,7 @@ describe('Master Function appstats.js Units', function() {
     after(function() {
     });
     beforeEach(function() {
-        m_appstats.__set__({TableService : null});
+        m_appstats.__set__({g_tableService : null});
     });
     afterEach(function() {
     });


### PR DESCRIPTION
### Problem Description
`getTableService()` calls `_initTableService()` all the time due to `g_tableService` was never initialized.

### Solution description
Init `g_tableService` in `_initTableService()`

### Reviewers
@ikemsley @tomdos @alexturkin @andrey-smirnov 
