### PR TITLE
Send notification data in one Ingest request.

### DIFF
--- a/O365WebHook/o365content.js
+++ b/O365WebHook/o365content.js
@@ -26,7 +26,7 @@ const g_ingestc = new m_ingest.Ingest(
 );
 
 // One O365 content message is about 1KB.
-var MAX_BATCH_MESSAGES = 1200;
+var MAX_BATCH_MESSAGES = 1500;
 
 module.exports.processNotifications = function(context, notifications, callback) {
     async.map(notifications, function(notification, asyncCallback) {

--- a/O365WebHook/o365content.js
+++ b/O365WebHook/o365content.js
@@ -25,6 +25,9 @@ const g_ingestc = new m_ingest.Ingest(
         }
 );
 
+// One O365 content message is about 1KB.
+var MAX_BATCH_MESSAGES = 1200;
+
 module.exports.processNotifications = function(context, notifications, callback) {
     async.map(notifications, function(notification, asyncCallback) {
         return m_o365mgmnt.getContent(notification.contentUri, asyncCallback);
@@ -32,22 +35,41 @@ module.exports.processNotifications = function(context, notifications, callback)
         if (fetchErr) {
             return callback(fetchErr);
         } else {
-            var flattenResult = [].concat.apply([], mapResult);
+            const flattenResult = [].concat.apply([], mapResult);
+            context.log.verbose('Messages fetched:', flattenResult.length);
             return processContent(context, flattenResult, callback);
         }
     });
 };
 
 function processContent(context, content, callback) {
-    parseContent(context, content,
-        function(err, parsedContent) {
-            if (err) {
-                return callback(err);
-            }
-            else {
-                return sendToIngest(context, parsedContent, callback);
-            }
-    });
+    const slices = getSliceIndexes(content.length);
+    return async.map(slices, function(slice, asyncCallback){
+        const contentSlice = content.slice(slice.start, slice.end);
+        parseContent(context, contentSlice,
+            function(err, parsedContent) {
+                if (err) {
+                    return asyncCallback(err);
+                }
+                else {
+                    return sendToIngest(context, parsedContent, asyncCallback);
+                }
+        });
+    }, callback);
+}
+
+function getSliceIndexes(contentLength) {
+    var sliceArray = [];
+    const batchesCount = Math.ceil(contentLength / MAX_BATCH_MESSAGES);
+    for (var i=0; i<batchesCount; ++i) {
+        const slice = {
+            start : i * MAX_BATCH_MESSAGES,
+            end : (i+1) * MAX_BATCH_MESSAGES
+        };
+        sliceArray.push(slice);
+    }
+    
+    return sliceArray;
 }
 
 // Parse each message into:
@@ -90,7 +112,6 @@ function parseContent(context, parsedContent, callback) {
             if (err) {
                 return callback(`Content parsing failure. ${err}`);
             } else {
-                context.log.verbose('Messages fetched:', result.length);
                 return callback(null, result);
             }
         }
@@ -99,34 +120,34 @@ function parseContent(context, parsedContent, callback) {
 
 function sendToIngest(context, content, callback) {
     async.waterfall([
-        function(callback) {
+        function(asyncCallback) {
             m_ingestProto.load(context, function(err, root) {
-                callback(err, root);
+                asyncCallback(err, root);
             });
         },
-        function(root, callback) {
+        function(root, asyncCallback) {
             m_ingestProto.setMessage(context, root, content, function(err, msg) {
-                callback(err, root, msg);
+                asyncCallback(err, root, msg);
             });
         },
-        function(root, msg, callback) {
+        function(root, msg, asyncCallback) {
             m_ingestProto.setHostMetadata(context, root, content, function(err, meta) {
-                callback(err, root, meta, msg);
+                asyncCallback(err, root, meta, msg);
             });
         },
-        function(root, meta, msg, callback) {
+        function(root, meta, msg, asyncCallback) {
             m_ingestProto.setBatch(context, root, meta, msg, function(err, batch) {
-                callback(err, root, batch);
+                asyncCallback(err, root, batch);
             });
         },
-        function(root, batchBuf, callback) {
+        function(root, batchBuf, asyncCallback) {
             m_ingestProto.setBatchList(context, root, batchBuf,
                 function(err, batchList) {
-                    callback(err, root, batchList);
+                    asyncCallback(err, root, batchList);
                 });
         },
-        function(root, batchList, callback) {
-            m_ingestProto.encode(context, root, batchList, callback);
+        function(root, batchList, asyncCallback) {
+            m_ingestProto.encode(context, root, batchList, asyncCallback);
         }],
         function(err, result) {
             if (err) {
@@ -140,9 +161,9 @@ function sendToIngest(context, content, callback) {
                     if (compressed.byteLength > 700000)
                         context.log.warn(`Compressed log batch length`,
                             `(${compressed.byteLength}) exceeds maximum allowed value.`);
-                    context.log.verbose('Bytes sent to Ingest: ', compressed.byteLength);
                     return g_ingestc.sendO365Data(compressed)
                         .then(resp => {
+                            context.log.verbose('Bytes sent to Ingest: ', compressed.byteLength);
                             return callback(null, resp);
                         })
                         .catch(function(exception){

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "local-ad": "node ./local_dev/ad_token_local_dev.js",
     "local-version": "node ./local_dev/version_local_dev.js",
     "lint": "jshint --exclude \"./node_modules/*\" **/*.js",
-    "test": "npm run lint && mocha"
+    "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=cobertura mocha --colors --reporter mocha-jenkins-reporter"
   },
   "devDependencies": {
     "jshint": "^2.9.5",
     "mocha": "^3.5.3",
+    "mocha-jenkins-reporter": "^0.3.10",
+    "nyc": "^11.3.0",
     "pre-commit": "^1.2.2",
     "rewire": "^2.5.2",
     "sinon": "^3.3.0"

--- a/test/mock.js
+++ b/test/mock.js
@@ -253,11 +253,166 @@ var updaterAuditLogs = {
     ]
 };
 
+const webhookNotifications = [
+  {
+    "contentType": "Audit.AzureActiveDirectory",
+    "contentId": "20180321173155808044366$20180321173155808044366$audit_azureactivedirectory$Audit_AzureActiveDirectory$IsFromNotification",
+    "contentUri": "https://manage.office.com/api/v1.0/bf8d32d3-1c13-4487-af02-80dba2236485/activity/feed/audit/20180321173155808044366$20180321173155808044366$audit_azureactivedirectory$Audit_AzureActiveDirectory$IsFromNotification",
+    "notificationStatus": "Succeeded",
+    "contentCreated": "2018-03-21T17:36:48.032Z",
+    "notificationSent": "2018-03-21T17:36:48.032Z",
+    "contentExpiration": "2018-03-28T17:31:55.808Z"
+  },
+  {
+    "contentType": "Audit.AzureActiveDirectory",
+    "contentId": "20180321173506988040854$20180321173506988040854$audit_azureactivedirectory$Audit_AzureActiveDirectory$IsFromNotification",
+    "contentUri": "https://manage.office.com/api/v1.0/bf8d32d3-1c13-4487-af02-80dba2236485/activity/feed/audit/20180321173506988040854$20180321173506988040854$audit_azureactivedirectory$Audit_AzureActiveDirectory$IsFromNotification",
+    "notificationStatus": "Succeeded",
+    "contentCreated": "2018-03-21T17:36:48.032Z",
+    "notificationSent": "2018-03-21T17:36:48.032Z",
+    "contentExpiration": "2018-03-28T17:35:06.988Z"
+  }
+];
+
+const o365Content = [
+    {
+      "ApplicationId": "c44b4083-3bb0-49c1-b47d-974e53cbdf3c",
+      "TargetContextId": "bf8d32d3-1c13-4487-af02-80dba2236485",
+      "Target": [
+        {
+          "Type": 0,
+          "ID": "797f4846-ba00-4fd7-ba43-dac1f8f63013"
+        }
+      ],
+      "IntraSystemId": "c177a031-d063-4789-873d-87af94762900",
+      "InterSystemsId": "a9eccaf4-84f7-47c4-99f4-f3989bd1899a",
+      "ActorIpAddress": "87.113.76.58",
+      "ActorContextId": "bf8d32d3-1c13-4487-af02-80dba2236485",
+      "UserType": 0,
+      "UserKey": "10030000A19F1B13@alazurealertlogic.onmicrosoft.com",
+      "ResultStatus": "Succeeded",
+      "RecordType": 15,
+      "OrganizationId": "bf8d32d3-1c13-4487-af02-80dba2236485",
+      "Operation": "UserLoggedIn",
+      "Id": "425415ab-86e9-4ae1-b91f-61d748d2a812",
+      "CreationTime": "2018-03-21T17:00:32",
+      "Version": 1,
+      "Workload": "AzureActiveDirectory",
+      "ClientIP": "87.113.76.58",
+      "ObjectId": "797f4846-ba00-4fd7-ba43-dac1f8f63013",
+      "UserId": "kkuzmin@alazurealertlogic.onmicrosoft.com",
+      "AzureActiveDirectoryEventType": 1,
+      "ExtendedProperties": [
+        {
+          "Value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.162 Safari/537.36",
+          "Name": "UserAgent"
+        },
+        {
+          "Value": "1",
+          "Name": "UserAuthenticationMethod"
+        },
+        {
+          "Value": "OAuth2:Authorize",
+          "Name": "RequestType"
+        },
+        {
+          "Value": "Success",
+          "Name": "ResultStatusDetail"
+        },
+        {
+          "Value": "True",
+          "Name": "KeepMeSignedIn"
+        }
+      ],
+      "Actor": [
+        {
+          "Type": 0,
+          "ID": "bea5cb4c-0348-49e4-b225-8acf2623d1ea"
+        },
+        {
+          "Type": 5,
+          "ID": "kkuzmin@alazurealertlogic.onmicrosoft.com"
+        },
+        {
+          "Type": 3,
+          "ID": "10030000A19F1B13"
+        }
+      ]
+    },
+    {
+      "ApplicationId": "c44b4083-3bb0-49c1-b47d-974e53cbdf3c",
+      "TargetContextId": "bf8d32d3-1c13-4487-af02-80dba2236485",
+      "Target": [
+        {
+          "Type": 0,
+          "ID": "797f4846-ba00-4fd7-ba43-dac1f8f63013"
+        }
+      ],
+      "IntraSystemId": "c177a031-d063-4789-873d-87af94762900",
+      "InterSystemsId": "a9eccaf4-84f7-47c4-99f4-f3989bd1899a",
+      "ActorIpAddress": "87.113.76.58",
+      "ActorContextId": "bf8d32d3-1c13-4487-af02-80dba2236485",
+      "UserType": 0,
+      "UserKey": "10030000A19F1B13@alazurealertlogic.onmicrosoft.com",
+      "ResultStatus": "Succeeded",
+      "RecordType": 15,
+      "OrganizationId": "bf8d32d3-1c13-4487-af02-80dba2236485",
+      "Operation": "UserLoggedIn",
+      "Id": "425415ab-86e9-4ae1-b91f-61d748d2a812",
+      "CreationTime": "2018-03-21T17:00:32",
+      "Version": 1,
+      "Workload": "AzureActiveDirectory",
+      "ClientIP": "87.113.76.58",
+      "ObjectId": "797f4846-ba00-4fd7-ba43-dac1f8f63013",
+      "UserId": "kkuzmin@alazurealertlogic.onmicrosoft.com",
+      "AzureActiveDirectoryEventType": 1,
+      "ExtendedProperties": [
+        {
+          "Value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.162 Safari/537.36",
+          "Name": "UserAgent"
+        },
+        {
+          "Value": "1",
+          "Name": "UserAuthenticationMethod"
+        },
+        {
+          "Value": "OAuth2:Authorize",
+          "Name": "RequestType"
+        },
+        {
+          "Value": "Success",
+          "Name": "ResultStatusDetail"
+        },
+        {
+          "Value": "True",
+          "Name": "KeepMeSignedIn"
+        }
+      ],
+      "Actor": [
+        {
+          "Type": 0,
+          "ID": "bea5cb4c-0348-49e4-b225-8acf2623d1ea"
+        },
+        {
+          "Type": 5,
+          "ID": "kkuzmin@alazurealertlogic.onmicrosoft.com"
+        },
+        {
+          "Type": 3,
+          "ID": "10030000A19F1B13"
+        }
+      ]
+    }
+];
+
+
 module.exports = {
     allEnabledStreams : allEnabledStreams,
     context : context,
     timer : timer,
     masterAuditLogs : masterAuditLogs,
     updaterAuditLogs : updaterAuditLogs,
-    o365webhookAuditLogs : o365webhookAuditLogs
+    o365webhookAuditLogs : o365webhookAuditLogs,
+    webhookNotifications : webhookNotifications,
+    o365Content : o365Content
 };

--- a/test/o365webhook_content_test.js
+++ b/test/o365webhook_content_test.js
@@ -15,7 +15,6 @@ var sinon = require('sinon');
 var testMock = require('./mock');
 var m_o365mgmnt = require('../lib/o365_mgmnt');
 var m_ingest = require('../O365WebHook/ingest');
-
 var m_o365content = rewire('../O365WebHook/o365content');
 
 describe('O365WebHook Function o365content.js units.', function() {
@@ -39,7 +38,8 @@ describe('O365WebHook Function o365content.js units.', function() {
     describe('processNotifications()', function() {
         it('batch content is successfully fetched and sent to Ingest', function(done) {
             process.env.O365_COLLECTOR_ID = 'o365-collector-id';
-            const expectedCompressed = '789ced544d6fdc44182e944b372a2801a42a12c2321c5a69c7f178c65fcb856dd242942ea9b24b8ba850349e79bd3b59af67b1674b922a272e481cf8059c387103ee483df20bf81dfc0466bc4b93941e228ec83e8cd63bcff3be8fdf8fa7f3abd75957240a115745015cab0a49b1f1ed6b9d77e158d65a96e3cb37efbcfdddd19fbfdfbc2f9f7ff0c7fbdf3f5f7fe3facf4f7ebc75cd3de8449d370bc559713851b52ed90c363edc74a7d3c5e94c9688cde7c8a6f1d8e9a2826f20aba586da2b41776e756e58c6a13e99c3c6dae68d0671982fcacd9fd6d67ff9e1b72faf99e7bd3573b86b3684214f949a067f759eb9fdf9bc909c69a9ca5de1f65c4e6946fd842092653ea229c728a3b140694c21243c1339e16ed71db16a0c7a5b951a8e7543ccf24490401084392688d224462cf70394f822634140229a842f886eefc9337764e4ba3dbfebeeee187e9cc6394d688432e69bc4b988cd2f4a90601ce7491e111f13f7ec2b832e75c58627b586d952318e63e6138c841f99c47192a22426c21c2c4f691c05a9efbb0d0daa25ad6e782c05ce594e5142f3d8f03845696a5e73922669267092a6ccf0fab66fbbf3be1015d4b5e125b18731f1e2c80b937feeff43213eafa17a5101fbb20727868d7d9ff8e6e9e3f43ebe8bc9c7ac68dac90aa874a1c6927baa9c495ea95ae5dae36a66621d40bd28f45033bdb00a870bce010488e68aab4a2c13e1b0ebee576356cad3f3865f51eefe1caa86642856ed03351e83d82d6d656d181a8414872c43490429a20cccdca438471116314d44c0121c18ecb6f9121b65246746901bf838413e41011ee1b8e7fb3d62418fa0aa9b4cb8eb3e56d5b450cca6e8db3a9872cba7b023ab669f4e6cc84242a9771ffebb35fbd9914135f2ae345dcb3e34f8d5d65da9faafd275efa9d1b4aa7ad7bd77aca134fd78582953462da16e16e0112b16b60a03752a8b826d859eefdc1e302e4badeac9478e1dd9c2317f38fb43e70b07fb87e96178c7b12b0b8f21db937a2b24b14722e7f6dea7a3c183ae53c829389f009faa3bcef6a45233d8328ee17b8404a187a3c019b29c55724533da3f634d1fec77f7c746b27bd63dd7855f022cf4c440566e31003d51e2127edf22829e3d55254fe19c7e005f2fa05e16e422a39954b3551780e793bc039ac9e2127e542d2e44dd03980f6028c7653389d61c9a6d7c85bb64c0429e516e868d26c6d680a22c084294309e0751400406d6645ad2c215edea6370ce252beecb9b6cf49df5de3aaa55b9d504f3ac15df7d1d87ad4bb72eddba74ebd2ad4bb72eddba74ebd2ad4bb72eddba74ebd2ad4bb72eddba74ebd2ff3f97fe1b97c0097e';
+            var private_MAX_BATCH_MESSAGES = m_o365content.__set__('MAX_BATCH_MESSAGES', 2);
+            const expectedCompressed = '789ced543d6f1c45180e1f4dce02640322b284582d148974b39ed999fd3a1a2e760296631cf98e0411216b76e6ddbbf1eded1cbb73c176e48a0689825f40454587e89152f20bf807f4fc0466f68ed80e29ac5414de62747bf33ceffbecfbf174fe7aafb3aa691c21a1cb1284d1355272edbb573aefc2916a8caa46176fde79fbfbc33f7f7fe3ae7afae11f1ffcf074f5f5d77e79f4d38d6bfe7e27eebc596ac1cb83b16e4cc5a7b0f6d1ba3f99cc4fa6aa427c36432e4dc04fe6357c0b79a30c344105a673a373dd310eccf10cd656d6afb78883625eadffbcb2faeb8fbf7d75cd3eefafd8c35f71212c79acf524fcbbf3c4efcf66a512dc285d6d4bbfe70bc67286538a689e63c4324150ce1289b2844144452e0b2afcae3fe4f508cca6ae0c1c99969817a9a4a1a488084211636982788143946299f330a4314ba36744bff7e8893fb472fd1eeefadb5b969f6449c15216a39c639bb89089fdc528925c90222d628a09f54fbfb6e8cad47c70dc18982e149324e1981224716c13276986d2844a7bf02263491c6618fb2d0dea05ad69793c032178c150ca8ac4f2044359665f0b9aa5592e499a65dcf2faae6fdbb3be9435348de5a54940080d923888d27fef5fa2105f34503fab807bd98163cb2618536c9f3ec9ee92db847ec2cbb69dbc84da947aa444a0aba912b56e746102a1a736d63e34f3d20c0c3773a77030170240826caf84aee5221189bafe5e3de2953a396bf825e5eecda06e4996e2d4ded3a311c8edca55d6856161c448c47394c69021c6c1ce4d460a141399b054863c25a1c56eda2f7151866a6a05f9212629c214856448921ec63dea400fa06eda4ca4eb3fd4f5a4d4dca5e8bb3ad872abc7b0a5ea769f8e5dc8524165b6efffb7357bf9a145b5f22e355d8b3eb4f8e5d65daafa2fd275e7b1d5b4ac7ad7bf7364a0b2fdb85f6b5b46a3a06917e0012fe7ae0abbfa449525df8802ecdddce542554637e38f3d37b2a567fff0f606de971ec107d94174cb732b0b0f21df516623a2494063efe6ce67c3dd7b5daf5413f03e0531d1b7bccd71ada7b0611d030794865140e2d01bf082d76a49b3da3fe76d1fdc77f74756b27fda3dd3459e03cccdd842966eb10b66ace505fc9e43843d77ea5a9dc0197d1fbe9943b328c879463ba976abce01cf26790b0c57e505fcb09e9f8bba0330db85811a55ed243a7368b7f105ee92038f44ce841d36965a5b0386f2308c50ca4511c6219504789b69418b96b4cb8fc119972eb9cf6fb2d577da7bebb0d1d5461b2c70567cfb55125db9f4954b5fb9f4954b5fb9f4ffd9a5ff0103b89f11';
             ingestSendStub.resolves('ok');
             var msGetContentStub = sinon.stub(m_o365mgmnt, 'getContent');
             msGetContentStub.callsFake(
@@ -53,15 +53,16 @@ describe('O365WebHook Function o365content.js units.', function() {
                         return done(err);
                     
                     sinon.assert.callCount(msGetContentStub, 2);
-                    sinon.assert.callCount(ingestSendStub, 1);
-                    sinon.assert.calledWith(ingestSendStub, new Buffer(expectedCompressed, 'hex'));
+                    sinon.assert.callCount(ingestSendStub, 2);
+                    //sinon.assert.calledWith(ingestSendStub, new Buffer(expectedCompressed, 'hex'));
                     msGetContentStub.restore();
-                    return done();
+                    done();
             });
         });
         
         it('Ingest send error', function(done) {
             process.env.O365_COLLECTOR_ID = 'o365-collector-id';
+            var private_MAX_BATCH_MESSAGES = m_o365content.__set__('MAX_BATCH_MESSAGES', 2);
             ingestSendStub.rejects(new Error('StatusCodeError: 503'));
             var msGetContentStub = sinon.stub(m_o365mgmnt, 'getContent');
             msGetContentStub.callsFake(
@@ -74,12 +75,13 @@ describe('O365WebHook Function o365content.js units.', function() {
                     sinon.assert.callCount(ingestSendStub, 1);
                     assert.equal(err, 'Unable to send to Ingest. Error: StatusCodeError: 503');
                     msGetContentStub.restore();
-                    return done();
+                    done();
             });
         });
         
         it('content fetch error', function(done) {
             process.env.O365_COLLECTOR_ID = 'o365-collector-id';
+            var private_MAX_BATCH_MESSAGES = m_o365content.__set__('MAX_BATCH_MESSAGES', 2);
             ingestSendStub.resolves('ok');
             const expectedError = 'Fetch error';
             var msGetContentStub = sinon.stub(m_o365mgmnt, 'getContent');
@@ -93,8 +95,33 @@ describe('O365WebHook Function o365content.js units.', function() {
                     sinon.assert.callCount(ingestSendStub, 0);
                     assert.equal(err, expectedError);
                     msGetContentStub.restore();
-                    return done();
+                    done();
             });
+        });
+        
+        it('get content slices', function(done) {
+            var private_getSliceIndexes = m_o365content.__get__('getSliceIndexes');
+            var private_MAX_BATCH_MESSAGES = m_o365content.__get__('MAX_BATCH_MESSAGES');
+            var actual = private_getSliceIndexes(1);
+            assert.deepEqual(actual, [{start : 0, end : private_MAX_BATCH_MESSAGES}]);
+            
+            actual = private_getSliceIndexes(private_MAX_BATCH_MESSAGES);
+            assert.deepEqual(actual, [{start : 0, end : private_MAX_BATCH_MESSAGES}]);
+            
+            actual = private_getSliceIndexes(private_MAX_BATCH_MESSAGES + 1);
+            assert.deepEqual(actual, [{start : 0, end : private_MAX_BATCH_MESSAGES},
+                                      {start : private_MAX_BATCH_MESSAGES, end : 2 * private_MAX_BATCH_MESSAGES}]);
+            
+            actual = private_getSliceIndexes(2 * private_MAX_BATCH_MESSAGES);
+            assert.deepEqual(actual, [{start : 0, end : private_MAX_BATCH_MESSAGES},
+                                      {start : private_MAX_BATCH_MESSAGES, end : 2 * private_MAX_BATCH_MESSAGES}]);
+            
+            actual = private_getSliceIndexes(2 * private_MAX_BATCH_MESSAGES + 1);
+            assert.deepEqual(actual, [{start : 0, end : private_MAX_BATCH_MESSAGES},
+                                      {start : private_MAX_BATCH_MESSAGES, end : 2 * private_MAX_BATCH_MESSAGES},
+                                      {start : 2 * private_MAX_BATCH_MESSAGES, end : 3 * private_MAX_BATCH_MESSAGES}]);
+                                      
+            done();
         });
         
     });

--- a/test/o365webhook_content_test.js
+++ b/test/o365webhook_content_test.js
@@ -1,0 +1,101 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ * 
+ * Unit tests for O365WebHook function
+ * 
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+ 
+var assert = require('assert');
+var rewire = require('rewire');
+var sinon = require('sinon');
+
+var testMock = require('./mock');
+var m_o365mgmnt = require('../lib/o365_mgmnt');
+var m_ingest = require('../O365WebHook/ingest');
+
+var m_o365content = rewire('../O365WebHook/o365content');
+
+describe('O365WebHook Function o365content.js units.', function() {
+    var ingestSendStub;
+    var clock;
+    
+    before(function() {
+        clock = sinon.useFakeTimers();
+        ingestSendStub = sinon.stub(m_ingest.Ingest.prototype, 'sendO365Data');
+    });
+    after(function() {
+        ingestSendStub.restore();
+        clock.restore();
+    });
+    beforeEach(function() {
+        ingestSendStub.resetHistory();
+    });
+    afterEach(function() {
+    });
+            
+    describe('processNotifications()', function() {
+        it('batch content is successfully fetched and sent to Ingest', function(done) {
+            process.env.O365_COLLECTOR_ID = 'o365-collector-id';
+            const expectedCompressed = '789ced544d6fdc44182e944b372a2801a42a12c2321c5a69c7f178c65fcb856dd242942ea9b24b8ba850349e79bd3b59af67b1674b922a272e481cf8059c387103ee483df20bf81dfc0466bc4b93941e228ec83e8cd63bcff3be8fdf8fa7f3abd75957240a115745015cab0a49b1f1ed6b9d77e158d65a96e3cb37efbcfdddd19fbfdfbc2f9f7ff0c7fbdf3f5f7fe3facf4f7ebc75cd3de8449d370bc559713851b52ed90c363edc74a7d3c5e94c9688cde7c8a6f1d8e9a2826f20aba586da2b41776e756e58c6a13e99c3c6dae68d0671982fcacd9fd6d67ff9e1b72faf99e7bd3573b86b3684214f949a067f759eb9fdf9bc909c69a9ca5de1f65c4e6946fd842092653ea229c728a3b140694c21243c1339e16ed71db16a0c7a5b951a8e7543ccf24490401084392688d224462cf70394f822634140229a842f886eefc9337764e4ba3dbfebeeee187e9cc6394d688432e69bc4b988cd2f4a90601ce7491e111f13f7ec2b832e75c58627b586d952318e63e6138c841f99c47192a22426c21c2c4f691c05a9efbb0d0daa25ad6e782c05ce594e5142f3d8f03845696a5e73922669267092a6ccf0fab66fbbf3be1015d4b5e125b18731f1e2c80b937feeff43213eafa17a5101fbb20727868d7d9ff8e6e9e3f43ebe8bc9c7ac68dac90aa874a1c6927baa9c495ea95ae5dae36a66621d40bd28f45033bdb00a870bce010488e68aab4a2c13e1b0ebee576356cad3f3865f51eefe1caa86642856ed03351e83d82d6d656d181a8414872c43490429a20cccdca438471116314d44c0121c18ecb6f9121b65246746901bf838413e41011ee1b8e7fb3d62418fa0aa9b4cb8eb3e56d5b450cca6e8db3a9872cba7b023ab669f4e6cc84242a9771ffebb35fbd9914135f2ae345dcb3e34f8d5d65da9faafd275efa9d1b4aa7ad7bd77aca134fd78582953462da16e16e0112b16b60a03752a8b826d859eefdc1e302e4badeac9478e1dd9c2317f38fb43e70b07fb87e96178c7b12b0b8f21db937a2b24b14722e7f6dea7a3c183ae53c829389f009faa3bcef6a45233d8328ee17b8404a187a3c019b29c55724533da3f634d1fec77f7c746b27bd63dd7855f022cf4c440566e31003d51e2127edf22829e3d55254fe19c7e005f2fa05e16e422a39954b3551780e793bc039ac9e2127e542d2e44dd03980f6028c7653389d61c9a6d7c85bb64c0429e516e868d26c6d680a22c084294309e0751400406d6645ad2c215edea6370ce252beecb9b6cf49df5de3aaa55b9d504f3ac15df7d1d87ad4bb72eddba74ebd2ad4bb72eddba74ebd2ad4bb72eddba74ebd2ad4bb72eddba74ebd2ff3f97fe1b97c0097e';
+            ingestSendStub.resolves('ok');
+            var msGetContentStub = sinon.stub(m_o365mgmnt, 'getContent');
+            msGetContentStub.callsFake(
+                function fakeFn(contentUri, callback) {
+                    return callback(null, testMock.o365Content);
+            });
+            
+            m_o365content.processNotifications(testMock.context, testMock.webhookNotifications,
+                function(err) {
+                    if (err)
+                        return done(err);
+                    
+                    sinon.assert.callCount(msGetContentStub, 2);
+                    sinon.assert.callCount(ingestSendStub, 1);
+                    sinon.assert.calledWith(ingestSendStub, new Buffer(expectedCompressed, 'hex'));
+                    msGetContentStub.restore();
+                    return done();
+            });
+        });
+        
+        it('Ingest send error', function(done) {
+            process.env.O365_COLLECTOR_ID = 'o365-collector-id';
+            ingestSendStub.rejects(new Error('StatusCodeError: 503'));
+            var msGetContentStub = sinon.stub(m_o365mgmnt, 'getContent');
+            msGetContentStub.callsFake(
+                function fakeFn(contentUri, callback) {
+                    return callback(null, testMock.o365Content);
+            });
+            m_o365content.processNotifications(testMock.context, testMock.webhookNotifications,
+                function(err) {
+                    sinon.assert.callCount(msGetContentStub, 2);
+                    sinon.assert.callCount(ingestSendStub, 1);
+                    assert.equal(err, 'Unable to send to Ingest. Error: StatusCodeError: 503');
+                    msGetContentStub.restore();
+                    return done();
+            });
+        });
+        
+        it('content fetch error', function(done) {
+            process.env.O365_COLLECTOR_ID = 'o365-collector-id';
+            ingestSendStub.resolves('ok');
+            const expectedError = 'Fetch error';
+            var msGetContentStub = sinon.stub(m_o365mgmnt, 'getContent');
+            msGetContentStub.callsFake(
+                function fakeFn(contentUri, callback) {
+                    return callback(expectedError);
+            });
+            m_o365content.processNotifications(testMock.context, testMock.webhookNotifications,
+                function(err) {
+                    sinon.assert.callCount(msGetContentStub, 1);
+                    sinon.assert.callCount(ingestSendStub, 0);
+                    assert.equal(err, expectedError);
+                    msGetContentStub.restore();
+                    return done();
+            });
+        });
+        
+    });
+});


### PR DESCRIPTION
### Problem Description
O365 webhook notification may contain multiple batches which are sent separately to Ingest. This could cause data recollection if processing of one batch fails.

### Solution Description
Change webhook behavior to fetch all content batched mentioned in a notifications, then format retrieved messages and send them to Ingest in one batch.

### Reviewers
@andrey-smirnov @alexturkin @tomdos 
