### PR TITLE
Add optionale parsed properties only if they exist

### DIFF
--- a/O365WebHook/formatO365Log.js
+++ b/O365WebHook/formatO365Log.js
@@ -38,10 +38,10 @@ module.exports = function(item) {
     };
     
     if (messageTypeId) {
-        Object.assign(formattedMsg, {messageTypeId: `${messageTypeId}`});
+        formattedMsg.messageTypeId = `${messageTypeId}`;
     }
     if (creationTime.usec) {
-        Object.assign(formattedMsg, {messageTsUs: creationTime.usec});
+        formattedMsg.messageTsUs = creationTime.usec;
     }
     return formattedMsg;
 };

--- a/O365WebHook/formatO365Log.js
+++ b/O365WebHook/formatO365Log.js
@@ -29,15 +29,19 @@ module.exports = function(item) {
 
     let creationTime = Parse.getMsgTs(item, creationTimePaths);
     let messageTypeId = Parse.getMsgTypeId(item, messageTypeIdPaths);
-
-    return {
+    let formattedMsg = {
         messageTs: creationTime.sec,
         priority: 11,
         progName: 'o365webhook',
-        pid: undefined,
         message: message,
-        messageType: 'json/azure.o365',
-        messageTypeId: `${messageTypeId}`,
-        messageTsUs: creationTime.usec ? creationTime.usec : undefined
+        messageType: 'json/azure.o365'
     };
+    
+    if (messageTypeId) {
+        Object.assign(formattedMsg, {messageTypeId: `${messageTypeId}`});
+    }
+    if (creationTime.usec) {
+        Object.assign(formattedMsg, {messageTsUs: creationTime.usec});
+    }
+    return formattedMsg;
 };

--- a/test/formatO365Log_test.js
+++ b/test/formatO365Log_test.js
@@ -3,21 +3,37 @@ const formatO365Log = require('../O365WebHook/formatO365Log');
 const mock = require('./mock');
 
 describe('formatO365 units', function(){
-    it('Formats a O365 log correctly', function(done){
-        const logRecord = mock.o365Content[0];
+    it('Formats a O365 log correctly, no optional properties', function(done){
+        let logRecord = Object.assign({}, mock.o365Content[0]);
+        delete logRecord.RecordType;
         const formattedRecord = formatO365Log(logRecord);
 
         const expectedRecord = {
             messageTs: new Date(logRecord.CreationTime).getTime() / 1000,
             priority: 11,
             progName: 'o365webhook',
-            pid: undefined,
+            message: JSON.stringify(logRecord),
+            messageType: 'json/azure.o365'
+        };
+
+        assert.deepEqual(formattedRecord, expectedRecord);
+        done();
+    });
+    
+    it('Formats a O365 log correctly, with optional properties', function(done){
+        let logRecord = Object.assign({}, mock.o365Content[0]);
+        logRecord.CreationTime = "2018-03-21T17:00:32.125Z";
+        const formattedRecord = formatO365Log(logRecord);
+
+        const expectedRecord = {
+            messageTs: 1521651632,
+            priority: 11,
+            progName: 'o365webhook',
             message: JSON.stringify(logRecord),
             messageType: 'json/azure.o365',
             messageTypeId: `${logRecord.RecordType}`,
-            messageTsUs: undefined
+            messageTsUs: 125000
         };
-
 
         assert.deepEqual(formattedRecord, expectedRecord);
         done();


### PR DESCRIPTION
### Problem Description

Backend fails to parse protobuf which contain `undefined` filed.

### Solution description

Add optional message properties `messageTypeId` and `messageTsUs` only if its values are defined.
