### PR TITLE
Add forced update functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "async": "2.6.2",
     "azure": "2.0.0-preview",
     "path": "0.12.7",
-    "@alertlogic/al-azure-collector-js": "1.2.0",
+    "@alertlogic/al-azure-collector-js": "1.3.0",
     "@alertlogic/al-collector-js": "1.3.0",
     "request-promise-native": "1.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure_collector",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "dependencies": {
     "async": "2.6.2",
     "azure": "2.0.0-preview",


### PR DESCRIPTION
This PR updates the dependency for al-azure-collector-js library.

This will add the ability for alert logic to tell collectors to update themselves at checkin, rather that at the scheduled update time every 12 hours.