### PR TITLE
generate storage account name, remove template param, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ curl -X DELETE -H "x-aims-auth-token: $AL_TOKEN" https://api.global-services.glo
 
 ## Download and Deploy the ARM Template 
 
-You can use either the Microsoft Azure portal or a command line to deploy the template. To perform either procedure, you must log into the [Azure portal](https://portal.azure.com). 
+You can use either the Microsoft Azure portal or a command line to deploy the template. To perform either procedure, you must log into the [Azure portal](https://portal.azure.com).
 
-**Note:** The steps in this section require an active Azure subscription. To verify your Azure subscrption, visit [Azure subscriptions blade](https://portal.azure.com/#blade/Microsoft_Azure_Billing/SubscriptionsBlade).
+**Note:** The steps in this section require an active Azure subscription. To verify your Azure subscription, visit [Azure subscriptions blade](https://portal.azure.com/#blade/Microsoft_Azure_Billing/SubscriptionsBlade).
+
+**Note:** This template will deploy a storage account in the active Azure subscription, alongside the function app, in order to successfully collect Office 365 logs.
 
 If your organization uses multiple Active Directory tenants, log into the same tenant used to [Register a New Office 365 Web Application](#register-a-new-office-365-web-application). To find your Office 365 tenant ID, see [Find your Office 365 tenant ID](https://support.office.com/en-gb/article/find-your-office-365-tenant-id-6891b561-a52d-4ade-9f39-b492285e2c9b).
 
@@ -113,7 +115,6 @@ Click the button below to start deployment.
 1. Provide the following required template parameters and click the `Purchase` button to start a deployment:
    - `Name` - Type the name of the log source to appear in the Alert Logic console.
    - `Resource Group` - We recommend that you create a new resource group for the collector.
-   - `Storage Name` - Any storage account name (that does not currently exist).
    - `Alert Logic Access Key ID` - The `access_key_id` you created above
    - `Alert Logic Secret Key` - The `secret_key` you created above.
    - `Alert Logic API endpoint` - Leave the default value (api.global-services.global.alertlogic.com).

--- a/template.json
+++ b/template.json
@@ -5,9 +5,6 @@
         "Name": {
             "type": "String"
         },
-        "Storage Name": {
-            "type": "String"
-        },
         "Alert Logic Access Key ID": {
             "type": "String"
         },
@@ -47,6 +44,7 @@
         "location": "[resourceGroup().location]",
         "resourceGroupName": "[resourceGroup().name]",
         "resourceGroupId": "[resourceGroup().id]",
+        "webAppStorageAccountName": "[take(concat('alertlogicstorage', uniqueString(concat(subscription().tenantId, parameters('Application Name')))), 24)]",
         "roleAssignmentId": "[guid(uniqueString( resourceGroup().id, deployment().name ))]",
         "subscriptionId": "[split(subscription().id, '/')[2]]",
         "tenantId": "[subscription().tenantId]",
@@ -67,11 +65,11 @@
                     "appSettings": [
                         {
                             "name": "AzureWebJobsDashboard",
-                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('Storage Name'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('Storage Name')), '2015-06-15').key1)]"
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('webAppStorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('webAppStorageAccountName')), '2015-06-15').key1)]"
                         },
                         {
                             "name": "AzureWebJobsStorage",
-                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('Storage Name'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('Storage Name')), '2015-06-15').key1)]"
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('webAppStorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('webAppStorageAccountName')), '2015-06-15').key1)]"
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
@@ -87,7 +85,7 @@
                         },
                         {
                             "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('Storage Name'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('Storage Name')), '2015-06-15').key1)]"
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('webAppStorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts',variables('webAppStorageAccountName'), '2015-06-15').key1)]"
                         },
                         {
                             "name": "WEBSITE_CONTENTSHARE",
@@ -150,7 +148,7 @@
                 "clientAffinityEnabled": false
             },
             "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', parameters('Storage Name'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('webAppStorageAccountName'))]"
             ],
             "resources": [{
                 "apiVersion": "2015-08-01",
@@ -168,7 +166,7 @@
         },
         {
             "type": "Microsoft.Storage/storageAccounts",
-            "name": "[parameters('Storage Name')]",
+            "name": "[variables('webAppStorageAccountName')]",
             "apiVersion": "2015-06-15",
             "location": "[variables('location')]",
             "properties": {


### PR DESCRIPTION
Storage account name validation is broken in Azure, currently allowing you to have names that break their own naming restrictions. This leads to problems later in the deployment process. 
This change removes the option to specify storage account name as a parameter, the name is instead generated by the template itself. 
ReadMe is updated to reinforce that a storage account is still created.