### PR TITLE
fix for storage account name generation

### DIFF
--- a/template.json
+++ b/template.json
@@ -44,7 +44,7 @@
         "location": "[resourceGroup().location]",
         "resourceGroupName": "[resourceGroup().name]",
         "resourceGroupId": "[resourceGroup().id]",
-        "webAppStorageAccountName": "[take(concat('alertlogicstorage', uniqueString(concat(subscription().tenantId, parameters('Application Name')))), 24)]",
+        "webAppStorageAccountName": "[take(concat('alertlogicstorage', uniqueString(concat(subscription().tenantId, parameters('Name')))), 24)]",
         "roleAssignmentId": "[guid(uniqueString( resourceGroup().id, deployment().name ))]",
         "subscriptionId": "[split(subscription().id, '/')[2]]",
         "tenantId": "[subscription().tenantId]",


### PR DESCRIPTION
Currently pulling wrong parameter to generate storage account name, leading to some failures in deployment of template.
This resolves that by pulling correct param