### PR TITLE
Update runtime version in template; some janitorial duties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
+# Dev configs/artifacts
 ./local_dev/dev_config.js
+/.nyc_output
+/package-lock.json
+/node_modules
+/coverage
+/test/report.xml
 
+# Editor cruft
 .idea/
-node_modules/
 *.swp
+
+# macOS
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: all
+all: test
+
+deps: node_modules
+
+node_modules:
+	npm install
+
+.PHONY: compile
+compile: deps
+	npm run lint
+
+.PHONY: test
+test: compile
+	npm run test
+
+.PHONY: clean
+clean:
+	rm -f test/report.xml
+	rm -f package-lock.json
+	rm -rf coverage
+	rm -rf node_modules

--- a/template.json
+++ b/template.json
@@ -50,7 +50,9 @@
         "tenantId": "[subscription().tenantId]",
         "contributor": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
         "repo": "https://github.com/alertlogic/azure-collector.git",
-        "branch": "master"
+        "branch": "master",
+        "nodeRuntimeVersion": "~12",
+        "azureFunctionsExtensionVersion": "~3"
     },
     "resources": [
         {
@@ -73,7 +75,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~3"
+                            "value": "[variables('azureFunctionsExtensionVersion')]"
                         },
                         {
                             "name": "SCM_USE_FUNCPACK",
@@ -93,7 +95,7 @@
                         },
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "12.13.0"
+                            "value": "[variables('nodeRuntimeVersion')]"
                         },
                         {
                             "name": "O365_CONTENT_STREAMS",


### PR DESCRIPTION
### Problem
- NodeJS 12.13.0 is no longer available on the latest Azure Function App runtime

### Solution
- Specify only the NodeJS major version `~12` in the deployment template
- ~Update some dependencies~
- Add a makefile for big convenience